### PR TITLE
Improve mimiq as service

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/wendyliga/Explorer.git",
         "state": {
           "branch": null,
-          "revision": "c31815c61076122cab594249e1de9d5afd047d17",
-          "version": "0.0.4"
+          "revision": "a20c41d2001e9891ce7189b927386b11780d044b",
+          "version": "0.0.5"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "ConsoleIO",
         "repositoryURL": "https://github.com/wendyliga/ConsoleIO.git",
         "state": {
-          "branch": "improve_input",
-          "revision": "5849429bb2a5cb809d35a1f9e620ff1261b66501",
-          "version": null
+          "branch": null,
+          "revision": "3933eb8c8f4ce00d07c2a80896b6463bdf1d31d1",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "mimiq",
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
-        .package(url: "https://github.com/wendyliga/ConsoleIO.git", .branch("improve_input")),
+        .package(url: "https://github.com/wendyliga/ConsoleIO.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/wendyliga/Explorer.git", from: "0.0.3"),
     ],
     targets: [

--- a/Sources/mimiq/Extension.swift
+++ b/Sources/mimiq/Extension.swift
@@ -1,3 +1,27 @@
+/**
+MIT License
+
+Copyright (c) 2020 Wendy Liga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import Foundation
 
 // MARK: - JSONDecoder Extension

--- a/Sources/mimiq/ShellProvider+Mock.swift
+++ b/Sources/mimiq/ShellProvider+Mock.swift
@@ -1,0 +1,101 @@
+/**
+MIT License
+
+Copyright (c) 2020 Wendy Liga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import Explorer
+import Foundation
+
+
+// MARK: - Mock Shell Provider
+
+#if DEBUG
+let dummySimulator: [Simulator] = [
+    Simulator(udid: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, name: "Mimiq Simulator"),
+    Simulator(udid: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!, name: "Mimiq Simulator #2")
+]
+
+extension ShellProvider {
+    var isHomebrewInstalled: Bool {
+        true
+    }
+    
+    var isFFMpegInstalled: Bool {
+        true
+    }
+    
+    var availableSimulators: [Simulator] {
+        dummySimulator
+    }
+    
+    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
+        completion((0, nil, nil))
+    }
+    
+    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
+        (0, nil, nil)
+    }
+    
+    func list(at path: String, withFolder isFolderIncluded: Bool, isRecursive: Bool) -> Result<[Explorable], Error> {
+        .success([])
+    }
+}
+
+final class AvailableSimulatorShellProvider: ShellProvider {
+    
+    var availableSimulators: [Simulator] {
+        dummySimulator
+    }
+}
+
+final class NoneSimulatorShellProvider: ShellProvider {
+    var availableSimulators: [Simulator] {
+        []
+    }
+}
+
+final class NoHomebrewShellProvider: ShellProvider {
+    var isHomebrewInstalled: Bool {
+        false
+    }
+}
+
+final class NoFFMpegShellProvider: ShellProvider {
+    var isFFMpegInstalled: Bool {
+        false
+    }
+}
+
+final class FailedRecordShellProvider: ShellProvider {
+    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
+        completion((1, nil, "Failed to create mov file"))
+    }
+}
+
+final class FailedConvertingGIFShellProvider: ShellProvider {
+    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
+        (1, nil, "Failed to convert MOV to GIF")
+    }
+}
+
+final class SuccessShellProvider: ShellProvider {}
+#endif

--- a/Sources/mimiq/ShellProvider.swift
+++ b/Sources/mimiq/ShellProvider.swift
@@ -6,7 +6,7 @@ struct Runtime: Decodable {
     let identifier: String
 }
 
-struct Simulator: Decodable {
+struct Simulator: Codable {
     let udid: UUID
     let name: String
 }
@@ -97,9 +97,6 @@ final class DefaultShellProvider: ShellProvider {
     var availableSimulators: [Simulator] {
         let simulatorRuntimeListShellExecution = shell(arguments: ["xcrun simctl list -v runtimes --json"])
         
-        Log.default.write("fetching runtimes")
-        Log.default.write(simulatorRuntimeListShellExecution.output ?? "no ouput")
-        
         guard
             simulatorRuntimeListShellExecution.status == 0,
             let runtimeListRawData = simulatorRuntimeListShellExecution.output?.data(using: .utf8),
@@ -126,9 +123,6 @@ final class DefaultShellProvider: ShellProvider {
          */
 
         let simulatorListShellExecution = shell(arguments: ["xcrun simctl list -v devices booted --json"])
-        
-        Log.default.write("fetching booted devices")
-        Log.default.write(simulatorListShellExecution.output ?? "no ouput")
         
         guard
             simulatorListShellExecution.status == 0,
@@ -202,11 +196,11 @@ extension ShellProvider {
     }
     
     func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool) -> ShellResult {
-        (0,nil)
+        (0, nil, nil)
     }
     
     func convertMovToGif(movSource: String, gifTarget: String, printOutLog: Bool) -> ShellResult {
-        (0,nil)
+        (0, nil, nil)
     }
     
     func list(at path: String, withFolder isFolderIncluded: Bool, isRecursive: Bool) -> Result<[Explorable], Error> {
@@ -240,13 +234,13 @@ final class NoFFMpegShellProvider: ShellProvider {
 
 final class FailedRecordShellProvider: ShellProvider {
     func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool) -> ShellResult {
-        (1,"Failed to create mov file")
+        (1, nil, "Failed to create mov file")
     }
 }
 
 final class FailedConvertingGIFShellProvider: ShellProvider {
     func convertMovToGif(movSource: String, gifTarget: String, printOutLog: Bool) -> ShellResult {
-        (1,"Failed to convert MOV to GIF")
+        (1, nil, "Failed to convert MOV to GIF")
     }
 }
 

--- a/Sources/mimiq/ShellProvider.swift
+++ b/Sources/mimiq/ShellProvider.swift
@@ -1,4 +1,28 @@
 import Explorer
+/**
+MIT License
+
+Copyright (c) 2020 Wendy Liga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import Foundation
 import ConsoleIO
 
@@ -183,77 +207,3 @@ final class DefaultShellProvider: ShellProvider {
         Explorer.default.list(at: path, withFolder: isFolderIncluded, isRecursive: isRecursive)
     }
 }
-
-// MARK: - Mock Shell Provider
-
-#if DEBUG
-let dummySimulator: [Simulator] = [
-    Simulator(udid: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, name: "Mimiq Simulator"),
-    Simulator(udid: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!, name: "Mimiq Simulator #2")
-]
-
-extension ShellProvider {
-    var isHomebrewInstalled: Bool {
-        true
-    }
-    
-    var isFFMpegInstalled: Bool {
-        true
-    }
-    
-    var availableSimulators: [Simulator] {
-        dummySimulator
-    }
-    
-    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
-        completion((0, nil, nil))
-    }
-    
-    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
-        (0, nil, nil)
-    }
-    
-    func list(at path: String, withFolder isFolderIncluded: Bool, isRecursive: Bool) -> Result<[Explorable], Error> {
-        .success([])
-    }
-}
-
-final class AvailableSimulatorShellProvider: ShellProvider {
-    
-    var availableSimulators: [Simulator] {
-        dummySimulator
-    }
-}
-
-final class NoneSimulatorShellProvider: ShellProvider {
-    var availableSimulators: [Simulator] {
-        []
-    }
-}
-
-final class NoHomebrewShellProvider: ShellProvider {
-    var isHomebrewInstalled: Bool {
-        false
-    }
-}
-
-final class NoFFMpegShellProvider: ShellProvider {
-    var isFFMpegInstalled: Bool {
-        false
-    }
-}
-
-final class FailedRecordShellProvider: ShellProvider {
-    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
-        completion((1, nil, "Failed to create mov file"))
-    }
-}
-
-final class FailedConvertingGIFShellProvider: ShellProvider {
-    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
-        (1, nil, "Failed to convert MOV to GIF")
-    }
-}
-
-final class SuccessShellProvider: ShellProvider {}
-#endif

--- a/Sources/mimiq/ShellProvider.swift
+++ b/Sources/mimiq/ShellProvider.swift
@@ -205,11 +205,11 @@ extension ShellProvider {
         dummySimulator
     }
     
-    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool) -> ShellResult {
-        (0, nil, nil)
+    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
+        completion((0, nil, nil))
     }
     
-    func convertMovToGif(movSource: String, gifTarget: String, printOutLog: Bool) -> ShellResult {
+    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
         (0, nil, nil)
     }
     
@@ -219,6 +219,7 @@ extension ShellProvider {
 }
 
 final class AvailableSimulatorShellProvider: ShellProvider {
+    
     var availableSimulators: [Simulator] {
         dummySimulator
     }
@@ -243,13 +244,13 @@ final class NoFFMpegShellProvider: ShellProvider {
 }
 
 final class FailedRecordShellProvider: ShellProvider {
-    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool) -> ShellResult {
-        (1, nil, "Failed to create mov file")
+    func recordSimulator(target: Simulator, movTarget: String, printOutLog: Bool, completion: @escaping (ShellResult) -> Void) {
+        completion((1, nil, "Failed to create mov file"))
     }
 }
 
 final class FailedConvertingGIFShellProvider: ShellProvider {
-    func convertMovToGif(movSource: String, gifTarget: String, printOutLog: Bool) -> ShellResult {
+    func convertMovToGif(movSource: String, gifTarget: String, customFFMpegPath: String?, printOutLog: Bool) -> ShellResult {
         (1, nil, "Failed to convert MOV to GIF")
     }
 }

--- a/Sources/mimiq/main.swift
+++ b/Sources/mimiq/main.swift
@@ -329,9 +329,8 @@ struct Record: ParsableCommand {
         // MARK: - Check Not Linux
         
         #if os(Linux)
-            print("\(appName) is not support linux yet")
             log("mimiq is running on linux", printOut: isVerbose)
-            return
+            fatalError("\(appName) is not support linux yet")
         #endif
         
         log("mimiq is running on mac")
@@ -343,7 +342,7 @@ struct Record: ParsableCommand {
         
         guard configureEnvironment().successValue != nil else {
             log("failed setup environment")
-            print("💥 Failed to Setup Enviroment"); return
+            fatalError("💥 Failed to Setup Enviroment")
         }
         
         log("environment setup success")
@@ -352,7 +351,7 @@ struct Record: ParsableCommand {
         
         guard shellProvider.isHomebrewInstalled else {
             log("missing homebrew")
-            print("💥 Missing Homebrew, please install Homebrew, for more visit https://brew.sh"); return
+            fatalError("💥 Missing Homebrew, please install Homebrew, for more visit https://brew.sh")
         }
         
         log("Homebrew is installed")
@@ -362,14 +361,14 @@ struct Record: ParsableCommand {
         
         guard shellProvider.isFFMpegInstalled else {
             log("missing ffmpeg")
-            print("💥 Missing FFMpeg, please install mpeg, by executing `brew install ffmpeg`"); return
+            fatalError("💥 Missing FFMpeg, please install mpeg, by executing `brew install ffmpeg`")
         }
         
         // MARK: - Unwarp Mimiq Target
         
         guard let mimiqTarget = mimiqTarget else {
             log("no available simulator")
-            print("💥 No Available Simulator to mimiq"); return
+            fatalError("💥 No Available Simulator to mimiq")
         }
         
         log("simulator target \(mimiqTarget)")
@@ -389,7 +388,7 @@ struct Record: ParsableCommand {
             removeCache()
             log("error record simulator")
             logShellOutput(recordResult.output)
-            print("💥 Record Failed, Please Try Again"); return
+            fatalError("💥 Record Failed, Please Try Again")
         }
         
         log("stop recording")
@@ -408,7 +407,7 @@ struct Record: ParsableCommand {
             log("error generating GIF")
             logShellOutput(generateGIFResult.output)
             
-            print("💥 Failed on Creating GIF, Please Try Again"); return
+            fatalError("💥 Failed on Creating GIF, Please Try Again")
         }
         
         log("success generating GIF")

--- a/Sources/mimiq/main.swift
+++ b/Sources/mimiq/main.swift
@@ -104,6 +104,9 @@ struct List: ParsableCommand {
       discussion: ""
     )
     
+    @Flag(help: "Output available simulator to mimiq with JSON format")
+    var json: Bool
+    
     #if DEBUG
     enum Mode: String, ExpressibleByArgument {
         case available
@@ -132,13 +135,27 @@ struct List: ParsableCommand {
         
         let availableSimulators = shellProvider.availableSimulators
         guard availableSimulators.isNotEmpty else {
-            print("💥 No Available Simulator to mimiq"); return
+            print(json ? "[]" : "💥 No Available Simulator to mimiq"); return
         }
         
-        print("Available Simulator to mimiq: ")
-        availableSimulators.forEach { simulator in
-            print("✅ \(simulator.udid) \(simulator.name)")
+        var outputs = [String]()
+        
+        if json {
+            let jsonEncoder = JSONEncoder()
+            
+            do {
+                let jsonData = try jsonEncoder.encode(availableSimulators)
+                outputs.append(String(data: jsonData, encoding: .utf8) ?? "[]")
+            } catch {
+                Log.default.write(error.localizedDescription)
+                outputs.append("[]")
+            }
+        } else {
+            outputs.append("Available Simulator to mimiq: ")
+            outputs.append(contentsOf: availableSimulators.map { "✅ \($0.udid) \($0.name)" })
         }
+        
+        print(outputs.joined(separator: "\n"))
     }
 }
 

--- a/Sources/mimiq/main.swift
+++ b/Sources/mimiq/main.swift
@@ -329,8 +329,9 @@ struct Record: ParsableCommand {
         // MARK: - Check Not Linux
         
         #if os(Linux)
-            log("mimiq is running on linux", printOut: isVerbose)
-            fatalError("\(appName) is not support linux yet")
+        log("mimiq is running on linux", printOut: isVerbose)
+        print("\(appName) is not support linux yet")
+        Darwin.exit(EXIT_FAILURE)
         #endif
         
         log("mimiq is running on mac")
@@ -342,7 +343,9 @@ struct Record: ParsableCommand {
         
         guard configureEnvironment().successValue != nil else {
             log("failed setup environment")
-            fatalError("💥 Failed to Setup Enviroment")
+            
+            print("💥 Failed to Setup Enviroment")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         log("environment setup success")
@@ -351,7 +354,9 @@ struct Record: ParsableCommand {
         
         guard shellProvider.isHomebrewInstalled else {
             log("missing homebrew")
-            fatalError("💥 Missing Homebrew, please install Homebrew, for more visit https://brew.sh")
+            
+            print("💥 Missing Homebrew, please install Homebrew, for more visit https://brew.sh")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         log("Homebrew is installed")
@@ -361,14 +366,18 @@ struct Record: ParsableCommand {
         
         guard shellProvider.isFFMpegInstalled else {
             log("missing ffmpeg")
-            fatalError("💥 Missing FFMpeg, please install mpeg, by executing `brew install ffmpeg`")
+            
+            print("💥 Missing FFMpeg, please install mpeg, by executing `brew install ffmpeg`")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         // MARK: - Unwarp Mimiq Target
         
         guard let mimiqTarget = mimiqTarget else {
             log("no available simulator")
-            fatalError("💥 No Available Simulator to mimiq")
+            
+            print("💥 No Available Simulator to mimiq")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         log("simulator target \(mimiqTarget)")
@@ -379,7 +388,11 @@ struct Record: ParsableCommand {
         let movSource = tempFolder + UUID().uuidString + ".mov"
         
         log("simulator to record on \(movSource)")
-        logShellOutput(shell(arguments: ["xcodebuild -version"]).output) // log xcode version
+        
+        // log xcode version
+        let xcodeBuildVersion = shell(arguments: ["xcodebuild -version"])
+        logShellOutput(xcodeBuildVersion.output ?? "no ouput")
+        logShellOutput(xcodeBuildVersion.errorOuput ?? "no error ouput")
         
         let recordResult = shellProvider.recordSimulator(target: mimiqTarget, movTarget: movSource, printOutLog: isVerbose)
 
@@ -387,8 +400,11 @@ struct Record: ParsableCommand {
         guard recordResult.status == 0 else {
             removeCache()
             log("error record simulator")
-            logShellOutput(recordResult.output)
-            fatalError("💥 Record Failed, Please Try Again")
+            logShellOutput(recordResult.output ?? "no ouput")
+            logShellOutput(recordResult.errorOuput ?? "no error ouput")
+            
+            print("💥 Record Failed, Please Try Again")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         log("stop recording")
@@ -405,9 +421,11 @@ struct Record: ParsableCommand {
             // clear generated cache
             removeCache()
             log("error generating GIF")
-            logShellOutput(generateGIFResult.output)
+            logShellOutput(generateGIFResult.output ?? "no ouput")
+            logShellOutput(generateGIFResult.errorOuput ?? "no error ouput")
             
-            fatalError("💥 Failed on Creating GIF, Please Try Again")
+            print("💥 Failed on Creating GIF, Please Try Again")
+            Darwin.exit(EXIT_FAILURE)
         }
         
         log("success generating GIF")

--- a/Tests/mimiqTests/mimiqTests.swift
+++ b/Tests/mimiqTests/mimiqTests.swift
@@ -63,7 +63,7 @@ final class mimiqTests: XCTestCase {
     
     func test_record_failMakeGIF() throws {
         let expected = [
-            "⚙️  Creating GIF..",
+            "⚙️  Creating GIF...",
             "💥 Failed on Creating GIF, Please Try Again",
             ""]
             .joined(separator: "\n")
@@ -73,7 +73,7 @@ final class mimiqTests: XCTestCase {
     
     func test_record_success() throws {
         let expected = [
-            "⚙️  Creating GIF..",
+            "⚙️  Creating GIF...",
             "✅ Grab your GIF at ~/Desktop/mimiq.gif",
             ""]
             .joined(separator: "\n")
@@ -82,7 +82,7 @@ final class mimiqTests: XCTestCase {
     }
     
     func test_checkVersion() throws {
-        let expected = "current version 0.3.6\n"
+        let expected = "current version 0.3.7\n"
         
         XCTAssertEqual(try shellProcess(args: ["version"]), expected)
     }

--- a/Tests/mimiqTests/mimiqTests.swift
+++ b/Tests/mimiqTests/mimiqTests.swift
@@ -1,3 +1,27 @@
+/**
+MIT License
+
+Copyright (c) 2020 Wendy Liga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import XCTest
 import class Foundation.Bundle
 

--- a/Tests/mimiqTests/mimiqTests.swift
+++ b/Tests/mimiqTests/mimiqTests.swift
@@ -103,10 +103,30 @@ final class mimiqTests: XCTestCase {
         
         XCTAssertEqual(try shellProcess(args: ["list", "--mode", "none"]), expected)
     }
+    
+    func test_listSimulatorJSON_exist() throws {
+        let expected = "[{\"name\":\"Mimiq Simulator\",\"udid\":\"00000000-0000-0000-0000-000000000000\"},{\"name\":\"Mimiq Simulator #2\",\"udid\":\"11111111-1111-1111-1111-111111111111\"}]\n"
+        
+        XCTAssertEqual(try shellProcess(args: ["list", "--mode", "available", "--json"]), expected)
+    }
+    
+    func test_listSimulatorJSON_notExist() throws {
+        let expected = "[]\n"
+        
+        XCTAssertEqual(try shellProcess(args: ["list", "--mode", "none", "--json"]), expected)
+    }
 
     static var allTests = [
-//        ("test_record", test_record),
+        ("test_record_noHomebrewInstalled", test_record_noHomebrewInstalled),
+        ("test_record_noFFMpegInstalled", test_record_noFFMpegInstalled),
+        ("test_record_noSimulator", test_record_noSimulator),
+        ("test_record_failRecord", test_record_failRecord),
+        ("test_record_failMakeGIF", test_record_failMakeGIF),
+        ("test_record_success", test_record_success),
         ("test_checkVersion", test_checkVersion),
         ("test_listSimulator_exist", test_listSimulator_exist),
+        ("test_listSimulator_notExist", test_listSimulator_notExist),
+        ("test_listSimulatorJSON_exist", test_listSimulatorJSON_exist),
+        ("test_listSimulatorJSON_notExist", test_listSimulatorJSON_notExist)
     ]
 }


### PR DESCRIPTION
- add option to output mimiq list as json
- add option for using custom ffmpeg, with `--custom-ffmpeg` option
- separate stderr and stdout pipeline
- exit with `EXIT_FAILURE` status if operation failure
- convert mustInterupShell as async function with completion, improving async `Process`, to interupt `Process`, and retriving completion of it using `terminationHandler ` instead of `waitUntilExit` ( that on nature, purposily work for sync process).